### PR TITLE
Implement Clock-In API

### DIFF
--- a/app/controllers/clock_ins_controller.rb
+++ b/app/controllers/clock_ins_controller.rb
@@ -14,6 +14,7 @@ class ClockInsController < ApplicationController
   # GET /clock_ins/1
   # GET /clock_ins/1.json
   def show
+    render :show, status: :ok
   end
 
   # POST /clock_ins

--- a/app/controllers/clock_ins_controller.rb
+++ b/app/controllers/clock_ins_controller.rb
@@ -5,20 +5,20 @@ class ClockInsController < ApplicationController
 
   before_action :authorize_user
 
-  # GET /clock_ins
-  # GET /clock_ins.json
+  # GET /users/1/clock_ins
+  # GET /users/1/clock_ins.json
   def index
     @clock_ins = @user.clock_ins
   end
 
-  # GET /clock_ins/1
-  # GET /clock_ins/1.json
+  # GET /users/1/clock_ins/1
+  # GET /users/1/clock_ins/1.json
   def show
     render :show, status: :ok
   end
 
-  # POST /clock_in
-  # POST /clock_in.json
+  # POST /users/1/clock_in
+  # POST /users/1/clock_in.json
   def create
     @clock_in = @user.clock_ins.build(clock_in_params)
     @clock_in.clock_in_at = Time.now
@@ -30,8 +30,8 @@ class ClockInsController < ApplicationController
     end
   end
 
-  # PATCH/PUT /clock-out
-  # PATCH/PUT /clock-out.json
+  # PATCH /users/1/clock-out
+  # PATCH /users/1/clock-out.json
   def update
     @clock_in = @user.clock_ins.last
     @clock_in.clock_out_at = Time.now
@@ -43,10 +43,11 @@ class ClockInsController < ApplicationController
     end
   end
 
-  # DELETE /clock_ins/1
-  # DELETE /clock_ins/1.json
+  # DELETE /users/1/clock_ins/1
+  # DELETE /users/1/clock_ins/1.json
   def destroy
     @clock_in.destroy!
+    render json: { message: "OK" }, status: :ok
   end
 
   private

--- a/app/controllers/clock_ins_controller.rb
+++ b/app/controllers/clock_ins_controller.rb
@@ -1,0 +1,62 @@
+class ClockInsController < ApplicationController
+  include Authorization
+  before_action :set_user
+  before_action :set_clock_in, only: %i[ show update destroy ]
+
+  before_action :authorize_user
+
+  # GET /clock_ins
+  # GET /clock_ins.json
+  def index
+    @clock_ins = @user.clock_ins
+  end
+
+  # GET /clock_ins/1
+  # GET /clock_ins/1.json
+  def show
+  end
+
+  # POST /clock_ins
+  # POST /clock_ins.json
+  def create
+    @clock_in = @user.clock_ins.build(clock_in_params)
+
+    if @clock_in.save
+      render :show, status: :created
+    else
+      render json: @clock_in.errors, status: :unprocessable_entity
+    end
+  end
+
+  # PATCH/PUT /clock_ins/1
+  # PATCH/PUT /clock_ins/1.json
+  def update
+    if @clock_in.update(clock_in_params)
+      render :show, status: :ok
+    else
+      render json: @clock_in.errors, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /clock_ins/1
+  # DELETE /clock_ins/1.json
+  def destroy
+    @clock_in.destroy!
+  end
+
+  private
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_clock_in
+    @clock_in = @user.clock_ins.find(params.expect(:id))
+  end
+
+  def set_user
+    @user = User.find(params.expect(:user_id))
+  end
+
+  # Only allow a list of trusted parameters through.
+  def clock_in_params
+    params.expect(clock_in: [ :user_id, :duration, :clock_in_at, :clock_out_at ])
+  end
+end

--- a/app/controllers/concerns/authorization.rb
+++ b/app/controllers/concerns/authorization.rb
@@ -1,0 +1,19 @@
+module Authorization
+  extend ActiveSupport::Concern
+
+  # check if user is admin
+  def authorize_admin
+    if !@current_user.admin?
+      render json: { error: "Unauthorized" }, status: :unauthorized
+      nil
+    end
+  end
+
+  # check if user can access the resource
+  def authorize_user
+    if !@current_user.admin? && @current_user.id != @user.id
+      render json: { error: "Unauthorized" }, status: :unauthorized
+      nil
+    end
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,9 @@
 class UsersController < ApplicationController
+  include Authorization
+
   before_action :set_user, only: %i[ show update destroy ]
-  before_action :authorize, only: %i[ show update ]
+  before_action :authorize_admin, only: %i[ index destroy ]
+  before_action :authorize_user, only: %i[ show update ]
   skip_before_action :authenticate_user, only: [ :create ]
 
   # GET /users
@@ -17,7 +20,7 @@ class UsersController < ApplicationController
   # GET /users/1
   # GET /users/1.json
   def show
-    render json: @user
+    render :show, status: :ok, location: @user
   end
 
   # POST /users
@@ -58,14 +61,6 @@ class UsersController < ApplicationController
   # Use callbacks to share common setup or constraints between actions.
   def set_user
     @user = User.find(params.expect(:id))
-  end
-
-  # check if user can access the resource
-  def authorize
-    if !@current_user.admin? && @current_user.id != @user.id
-      render json: { error: "Unauthorized" }, status: :unauthorized
-      nil
-    end
   end
 
   # Only allow a list of trusted parameters through.

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -51,6 +51,7 @@ class UsersController < ApplicationController
   def destroy
     if @current_user.admin?
       @user.destroy!
+      render json: { message: "OK" }, status: :ok
     else
       render json: { error: "Unauthorized" }, status: :unauthorized
     end

--- a/app/models/clock_in.rb
+++ b/app/models/clock_in.rb
@@ -1,0 +1,3 @@
+class ClockIn < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   has_secure_password
+  has_many :clock_ins, dependent: :destroy
   validates :email, presence: true, uniqueness: true
   validates :password_digest, presence: true
 end

--- a/app/views/clock_ins/_clock_in.json.jbuilder
+++ b/app/views/clock_ins/_clock_in.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! clock_in, :id, :user_id, :duration, :clock_in_at, :clock_out_at, :created_at, :updated_at
+json.url user_clock_in_url(@user, clock_in, format: :json)

--- a/app/views/clock_ins/index.json.jbuilder
+++ b/app/views/clock_ins/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @clock_ins, partial: "clock_ins/clock_in", as: :clock_in

--- a/app/views/clock_ins/show.json.jbuilder
+++ b/app/views/clock_ins/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "clock_ins/clock_in", clock_in: @clock_in

--- a/app/views/users/_user.json.jbuilder
+++ b/app/views/users/_user.json.jbuilder
@@ -1,2 +1,2 @@
-json.extract! user, :id, :email, :name, :created_at, :updated_at
+json.extract! user, :id, :email, :name, :admin, :created_at, :updated_at
 json.url user_url(user, format: :json)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   post "sessions/create"
-  resources :users
+  resources :users do
+    resources :clock_ins
+  end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Rails.application.routes.draw do
   post "sessions/create"
   resources :users do
-    resources :clock_ins
+    patch "clock-out" => "clock_ins#update", on: :member
+    resources :clock_ins, path: "clock-ins", except: [ :update ]
   end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/db/migrate/20250414091501_create_clock_ins.rb
+++ b/db/migrate/20250414091501_create_clock_ins.rb
@@ -9,6 +9,6 @@ class CreateClockIns < ActiveRecord::Migration[8.0]
       t.timestamps
     end
 
-    add_index :clock_ins, [:user_id, :clock_in_at, :duration]
+    add_index :clock_ins, [ :user_id, :clock_in_at, :duration ]
   end
 end

--- a/db/migrate/20250414091501_create_clock_ins.rb
+++ b/db/migrate/20250414091501_create_clock_ins.rb
@@ -1,0 +1,14 @@
+class CreateClockIns < ActiveRecord::Migration[8.0]
+  def change
+    create_table :clock_ins, id: :uuid do |t|
+      t.references :user, null: false, foreign_key: true, type: :uuid
+      t.integer :duration
+      t.datetime :clock_in_at
+      t.datetime :clock_out_at
+
+      t.timestamps
+    end
+
+    add_index :clock_ins, [:user_id, :clock_in_at, :duration]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_13_140712) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_14_091501) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "clock_ins", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "user_id", null: false
+    t.integer "duration"
+    t.datetime "clock_in_at"
+    t.datetime "clock_out_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "clock_in_at", "duration"], name: "index_clock_ins_on_user_id_and_clock_in_at_and_duration"
+    t.index ["user_id"], name: "index_clock_ins_on_user_id"
+  end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -22,4 +33,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_13_140712) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
+
+  add_foreign_key "clock_ins", "users"
 end

--- a/test/controllers/clock_ins_controller_test.rb
+++ b/test/controllers/clock_ins_controller_test.rb
@@ -15,7 +15,7 @@ class ClockInsControllerTest < ActionDispatch::IntegrationTest
 
   test "should create clock_in" do
     assert_difference("ClockIn.count") do
-      post user_clock_ins_url(@user), headers: @header_user, params: { clock_in: { clockin_at: @clock_in.clock_in_at, clockout_at: @clock_in.clock_out_at, duration: @clock_in.duration, user_id: @clock_in.user_id } }, as: :json
+      post user_clock_ins_url(@user), headers: @header_user, params: { user_id: @clock_in.user_id }, as: :json
     end
 
     assert_response :created
@@ -26,8 +26,8 @@ class ClockInsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "should update clock_in" do
-    patch user_clock_in_url(@user, @clock_in), headers: @header_user, params: { clock_in: { clockin_at: @clock_in.clock_in_at, clockout_at: @clock_in.clock_out_at, duration: @clock_in.duration, user_id: @clock_in.user_id } }, as: :json
+  test "should perform clock out" do
+    patch clock_out_user_url(@user, @clock_in), headers: @header_user, params: { clock_in: { clockin_at: @clock_in.clock_in_at, clockout_at: @clock_in.clock_out_at, user_id: @clock_in.user_id } }, as: :json
     assert_response :success
   end
 

--- a/test/controllers/clock_ins_controller_test.rb
+++ b/test/controllers/clock_ins_controller_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+
+class ClockInsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    setup_user_auth
+    setup_admin_auth
+    setup_invalid_auth
+    @clock_in = clock_ins(:one)
+  end
+
+  test "should get index" do
+    get user_clock_ins_url(@user), headers: @header_user, as: :json
+    assert_response :success
+  end
+
+  test "should create clock_in" do
+    assert_difference("ClockIn.count") do
+      post user_clock_ins_url(@user), headers: @header_user, params: { clock_in: { clockin_at: @clock_in.clock_in_at, clockout_at: @clock_in.clock_out_at, duration: @clock_in.duration, user_id: @clock_in.user_id } }, as: :json
+    end
+
+    assert_response :created
+  end
+
+  test "should show clock_in" do
+    get user_clock_in_url(@user, @clock_in), headers: @header_user, as: :json
+    assert_response :success
+  end
+
+  test "should update clock_in" do
+    patch user_clock_in_url(@user, @clock_in), headers: @header_user, params: { clock_in: { clockin_at: @clock_in.clock_in_at, clockout_at: @clock_in.clock_out_at, duration: @clock_in.duration, user_id: @clock_in.user_id } }, as: :json
+    assert_response :success
+  end
+
+  test "should destroy clock_in" do
+    assert_difference("ClockIn.count", -1) do
+      delete user_clock_in_url(@user, @clock_in), headers: @header_user, as: :json
+    end
+
+    assert_response :no_content
+  end
+end

--- a/test/controllers/clock_ins_controller_test.rb
+++ b/test/controllers/clock_ins_controller_test.rb
@@ -6,13 +6,31 @@ class ClockInsControllerTest < ActionDispatch::IntegrationTest
     setup_admin_auth
     setup_invalid_auth
     @clock_in = clock_ins(:one)
+    @clock_in_admin = clock_ins(:two)
   end
 
+  # GET /users/1/clock_ins
   test "should get index" do
     get user_clock_ins_url(@user), headers: @header_user, as: :json
     assert_response :success
   end
 
+  test "should get index from other user for admin" do
+    get user_clock_ins_url(@user), headers: @header_admin, as: :json
+    assert_response :success
+  end
+
+  test "should not get index from other user for normal user" do
+    get user_clock_ins_url(@user_admin), headers: @header_user, as: :json
+    assert_response 401
+  end
+
+  test "should not get index if header invalid" do
+    get user_clock_ins_url(@user), headers: @header_invalid, as: :json
+    assert_response 401
+  end
+
+  # POST /users/1/clock_in
   test "should create clock_in" do
     assert_difference("ClockIn.count") do
       post user_clock_ins_url(@user), headers: @header_user, params: { user_id: @clock_in.user_id }, as: :json
@@ -21,21 +39,102 @@ class ClockInsControllerTest < ActionDispatch::IntegrationTest
     assert_response :created
   end
 
+  test "should create clock_in for other user for admin" do
+    assert_difference("ClockIn.count") do
+      post user_clock_ins_url(@user), headers: @header_admin, params: { user_id: @clock_in.user_id }, as: :json
+    end
+
+    assert_response :created
+  end
+
+  test "should not create clock_in for other user for normal user" do
+    assert_difference("ClockIn.count", 0) do
+      post user_clock_ins_url(@user_admin), headers: @header_user, params: { user_id: @clock_in_admin.user_id }, as: :json
+    end
+
+    assert_response 401
+  end
+
+  test "should not create clock_in if header invalid" do
+    assert_difference("ClockIn.count", 0) do
+      post user_clock_ins_url(@user), headers: @header_invalid, params: { user_id: @clock_in.user_id }, as: :json
+    end
+
+    assert_response 401
+  end
+
+  # GET /users/1/clock_ins/1
   test "should show clock_in" do
     get user_clock_in_url(@user, @clock_in), headers: @header_user, as: :json
     assert_response :success
   end
 
-  test "should perform clock out" do
-    patch clock_out_user_url(@user, @clock_in), headers: @header_user, params: { clock_in: { clockin_at: @clock_in.clock_in_at, clockout_at: @clock_in.clock_out_at, user_id: @clock_in.user_id } }, as: :json
+  test "should show clock_in from other user for admin" do
+    get user_clock_in_url(@user, @clock_in), headers: @header_admin, as: :json
     assert_response :success
   end
 
+  test "should not show clock_in from other user for normal user" do
+    get user_clock_in_url(@user_admin, @clock_in_admin), headers: @header_user, as: :json
+    assert_response 401
+  end
+
+  test "should not show clock_in if header invalid" do
+    get user_clock_in_url(@user, @clock_in), headers: @header_invalid, as: :json
+    assert_response 401
+  end
+
+  # PATCH /users/1/clock-out
+  test "should perform clock out" do
+    patch clock_out_user_url(@user, @clock_in), headers: @header_user, as: :json
+    assert_response :success
+  end
+
+  test "should perform clock out for other user for admin" do
+    patch clock_out_user_url(@user, @clock_in), headers: @header_admin, as: :json
+    assert_response :success
+  end
+
+  test "should not perform clock out for other user for normal user" do
+    patch clock_out_user_url(@user_admin, @clock_in), headers: @header_user, as: :json
+    assert_response 401
+  end
+
+  test "should not perform clock out for other user if header invalid" do
+    patch clock_out_user_url(@user, @clock_in), headers: @header_invalid, as: :json
+    assert_response 401
+  end
+
+  # DELETE /users/1/clock_ins/1
   test "should destroy clock_in" do
     assert_difference("ClockIn.count", -1) do
       delete user_clock_in_url(@user, @clock_in), headers: @header_user, as: :json
     end
 
-    assert_response :no_content
+    assert_response :success
+  end
+
+  test "should destroy clock_in for other user for admin" do
+    assert_difference("ClockIn.count", -1) do
+      delete user_clock_in_url(@user, @clock_in), headers: @header_admin, as: :json
+    end
+
+    assert_response :success
+  end
+
+  test "should not destroy clock_in for other user for normal user" do
+    assert_difference("ClockIn.count", 0) do
+      delete user_clock_in_url(@user_admin, @clock_in_admin), headers: @header_user, as: :json
+    end
+
+    assert_response 401
+  end
+
+  test "should not destroy clock_in if header invalid" do
+    assert_difference("ClockIn.count", 0) do
+      delete user_clock_in_url(@user, @clock_in), headers: @header_invalid, as: :json
+    end
+
+    assert_response 401
   end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -88,7 +88,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       delete user_url(@user), headers: @header_admin, as: :json
     end
 
-    assert_response :no_content
+    assert_response :success
   end
 
   test "should not destroy user for normal user" do

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -2,21 +2,9 @@ require "test_helper"
 
 class UsersControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @user = users(:one)
-    token = Authentication.encode_jwt_token(user_id: @user.id)
-    @header = {
-      'Authorization': "Bearer #{token}"
-    }
-
-    @user_admin = users(:two)
-    token_admin = Authentication.encode_jwt_token(user_id: @user_admin.id)
-    @header_admin = {
-      'Authorization': "Bearer #{token_admin}"
-    }
-
-    @header_invalid = {
-      'Authorization': "Bearer aaa"
-    }
+    setup_user_auth
+    setup_admin_auth
+    setup_invalid_auth
   end
 
   # GET /users
@@ -26,7 +14,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should not get index for normal user" do
-    get users_url, headers: @header, as: :json
+    get users_url, headers: @header_user, as: :json
     assert_response 401
   end
 
@@ -54,7 +42,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
   # GET /users/1
   test "should show user" do
-    get user_url(@user), headers: @header, as: :json
+    get user_url(@user), headers: @header_user, as: :json
     assert_response :success
   end
 
@@ -64,7 +52,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should not show other user for normal  user" do
-    get user_url(@user_admin), headers: @header, as: :json
+    get user_url(@user_admin), headers: @header_user, as: :json
     assert_response 401
   end
 
@@ -75,7 +63,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
   # PATCH/PUT /users/1
   test "should update user" do
-    patch user_url(@user), headers: @header, params: { user: { email: @user.email, name: @user.name, password: "test", password_confirmation: "test" } }, as: :json
+    patch user_url(@user), headers: @header_user, params: { user: { email: @user.email, name: @user.name, password: "test", password_confirmation: "test" } }, as: :json
     assert_response :success
   end
 
@@ -85,7 +73,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should not update other user for normal  user" do
-    patch user_url(@user_admin), headers: @header, params: { user: { email: @user.email, name: @user.name, password: "test", password_confirmation: "test" } }, as: :json
+    patch user_url(@user_admin), headers: @header_user, params: { user: { email: @user.email, name: @user.name, password: "test", password_confirmation: "test" } }, as: :json
     assert_response 401
   end
 
@@ -105,7 +93,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
   test "should not destroy user for normal user" do
     assert_difference("User.count", 0) do
-      delete user_url(@user), headers: @header, as: :json
+      delete user_url(@user), headers: @header_user, as: :json
     end
 
     assert_response 401

--- a/test/fixtures/clock_ins.yml
+++ b/test/fixtures/clock_ins.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  duration: 1
+  clock_in_at: 2025-04-14 16:15:01
+  clock_out_at: 2025-04-14 16:15:01
+
+two:
+  user: two
+  duration: 1
+  clock_in_at: 2025-04-14 16:15:01
+  clock_out_at: 2025-04-14 16:15:01

--- a/test/models/clock_in_test.rb
+++ b/test/models/clock_in_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ClockInTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,5 +11,27 @@ module ActiveSupport
     fixtures :all
 
     # Add more helper methods to be used by all tests here...
+    def setup_user_auth
+      @user = users(:one)
+      @header_user = setup_valid_auth(@user)
+    end
+
+    def setup_admin_auth
+      @user_admin = users(:two)
+      @header_admin = setup_valid_auth(@user_admin)
+    end
+
+    def setup_valid_auth(user)
+      token = Authentication.encode_jwt_token(user_id: user.id)
+      header_admin = {
+        'Authorization': "Bearer #{token}"
+      }
+    end
+
+    def setup_invalid_auth
+      @header_invalid = {
+        'Authorization': "Bearer aaa"
+      }
+    end
   end
 end


### PR DESCRIPTION
Major updates:
- Implement Clock In APIs
All added APIs are protected:
- `POST /users/:user_id/clock-ins`
- `PATCH /users/:user_id/clock-out`
- `GET /users/:user_id/clock-ins`
- `GET /users/:user_id/clock-ins/:clock-in-id`
- `DELETE /users/:user_id/clock-ins/:clock-in-id`

Minor updates:
- Move shared codes in user resource to another files, so it can be used by clock-in resources
- Update response for `DELETE /users/:user_id`