### PR TITLE
Implement Followings API

### DIFF
--- a/app/controllers/followings_controller.rb
+++ b/app/controllers/followings_controller.rb
@@ -1,0 +1,63 @@
+class FollowingsController < ApplicationController
+  include Authorization
+  before_action :set_user
+  before_action :set_following, only: %i[ destroy ]
+  before_action :authorize_user
+
+  # GET /followings
+  # GET /followings.json
+  def index
+    @followings = @user.followings
+  end
+
+  # GET /followers
+  # GET /followers.json
+  def followers
+    @followings = @user.followers
+    render :index, status: :ok
+  end
+
+  # POST /follow
+  # POST /follow.json
+  def create
+    @following = @user.followings.build(following_params)
+
+    if @following.save
+      render :show, status: :created
+    else
+      render json: @following.errors, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /unfollow
+  # DELETE /unfollow.json
+  def destroy
+    if @following.nil?
+      render json: { message: "You are not following this user" }, status: :ok
+    else
+      @following.destroy!
+      render json: { message: "OK" }, status: :ok
+    end
+  end
+
+  private
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_user
+    if action_name == "index"
+      @user = User.find(params.expect(:user_id))
+      return
+    end
+
+    @user = User.find(params.expect(:id))
+  end
+
+  def set_following
+    @following = @user.followings.where(target_id: params.expect(:target_id)).first
+  end
+
+  # Only allow a list of trusted parameters through.
+  def following_params
+    { target_id: params.expect(:target_id) }
+  end
+end

--- a/app/models/following.rb
+++ b/app/models/following.rb
@@ -1,4 +1,13 @@
 class Following < ApplicationRecord
   belongs_to :user
   belongs_to :target, class_name: "User", foreign_key: "target_id"
+
+  validate :different_user
+  validates_uniqueness_of :target_id, scope: :user_id
+
+  def different_user
+    if user_id == target_id
+      errors.add(:target_id, "Can't follow you own account")
+    end
+  end
 end

--- a/app/models/following.rb
+++ b/app/models/following.rb
@@ -1,0 +1,4 @@
+class Following < ApplicationRecord
+  belongs_to :user
+  belongs_to :target, class_name: "User", foreign_key: "target_id"
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,9 @@
 class User < ApplicationRecord
   has_secure_password
   has_many :clock_ins, dependent: :destroy
+  has_many :followers, foreign_key: "target_id", class_name: "Following", dependent: :destroy
+  has_many :followings, foreign_key: "user_id", class_name: "Following", dependent: :destroy
+
   validates :email, presence: true, uniqueness: true
   validates :password_digest, presence: true
 end

--- a/app/views/followings/_following.json.jbuilder
+++ b/app/views/followings/_following.json.jbuilder
@@ -1,0 +1,1 @@
+json.extract! following, :id, :user_id, :target_id, :created_at, :updated_at

--- a/app/views/followings/index.json.jbuilder
+++ b/app/views/followings/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @followings, partial: "followings/following", as: :following

--- a/app/views/followings/show.json.jbuilder
+++ b/app/views/followings/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "followings/following", following: @following

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,10 @@ Rails.application.routes.draw do
   resources :users do
     patch "clock-out" => "clock_ins#update", on: :member
     resources :clock_ins, path: "clock-ins", except: [ :update ]
+    resources :followings, only: [ :index ]
+    post "follow/:target_id" => "followings#create", on: :member, as: "follow"
+    get "followers" => "followings#followers", on: :member
+    delete "unfollow/:target_id" => "followings#destroy", on: :member, as: "unfollow"
   end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/db/migrate/20250414122235_create_followings.rb
+++ b/db/migrate/20250414122235_create_followings.rb
@@ -1,0 +1,10 @@
+class CreateFollowings < ActiveRecord::Migration[8.0]
+  def change
+    create_table :followings, id: :uuid do |t|
+      t.references :user, null: false, foreign_key: true, type: :uuid
+      t.references :target, null: false, foreign_key: { to_table: :users }, type: :uuid
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250414122235_create_followings.rb
+++ b/db/migrate/20250414122235_create_followings.rb
@@ -6,5 +6,7 @@ class CreateFollowings < ActiveRecord::Migration[8.0]
 
       t.timestamps
     end
+
+    add_index :followings, [ :user_id, :target_id ], unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -31,6 +31,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_14_122235) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["target_id"], name: "index_followings_on_target_id"
+    t.index ["user_id", "target_id"], name: "index_followings_on_user_id_and_target_id", unique: true
     t.index ["user_id"], name: "index_followings_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_14_091501) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_14_122235) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -25,6 +25,15 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_14_091501) do
     t.index ["user_id"], name: "index_clock_ins_on_user_id"
   end
 
+  create_table "followings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "user_id", null: false
+    t.uuid "target_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["target_id"], name: "index_followings_on_target_id"
+    t.index ["user_id"], name: "index_followings_on_user_id"
+  end
+
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "name"
@@ -35,4 +44,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_14_091501) do
   end
 
   add_foreign_key "clock_ins", "users"
+  add_foreign_key "followings", "users"
+  add_foreign_key "followings", "users", column: "target_id"
 end

--- a/test/controllers/followings_controller_test.rb
+++ b/test/controllers/followings_controller_test.rb
@@ -6,18 +6,52 @@ class FollowingsControllerTest < ActionDispatch::IntegrationTest
     setup_admin_auth
     setup_invalid_auth
     @following = followings(:one)
+    @user3 = users(:three)
   end
 
+  # GET /followings
   test "should get index of followings" do
     get user_followings_url(@user), headers: @header_user, as: :json
     assert_response :success
   end
 
+  test "should get index of followings from other user for admin" do
+    get user_followings_url(@user), headers: @header_admin, as: :json
+    assert_response :success
+  end
+
+  test "should not get index of followings from other user for normal user" do
+    get user_followings_url(@user_admin), headers: @header_user, as: :json
+    assert_response 401
+  end
+
+  test "should not get index of followings if header invalid" do
+    get user_followings_url(@user), headers: @header_invalid, as: :json
+    assert_response 401
+  end
+
+  # GET /followers
   test "should get index of followers" do
     get followers_user_url(@user), headers: @header_user, as: :json
     assert_response :success
   end
 
+  test "should get index of followers from other user for admin" do
+    get followers_user_url(@user), headers: @header_admin, as: :json
+    assert_response :success
+  end
+
+  test "should not get index of followers from other user for normal user" do
+    get followers_user_url(@user_admin), headers: @header_user, as: :json
+    assert_response 401
+  end
+
+  test "should not get index of followers if header invalid" do
+    get followers_user_url(@user), headers: @header_invalid, as: :json
+    assert_response 401
+  end
+
+  # POST /follow
   test "should create following" do
     assert_difference("Following.count") do
       post follow_user_url(@user_admin, @user.id), headers: @header_admin, as: :json
@@ -26,11 +60,60 @@ class FollowingsControllerTest < ActionDispatch::IntegrationTest
     assert_response :created
   end
 
+  test "should create following for other user for admin" do
+    assert_difference("Following.count") do
+      post follow_user_url(@user, @user3.id), headers: @header_admin, as: :json
+    end
+
+    assert_response :created
+  end
+
+  test "should not create following for other user for normal user" do
+    assert_difference("Following.count", 0) do
+      post follow_user_url(@user_admin, @user3.id), headers: @header_user, as: :json
+    end
+
+    assert_response 401
+  end
+
+  test "should not create following if header invalid" do
+    assert_difference("Following.count", 0) do
+      post follow_user_url(@user, @user3.id), headers: @header_invalid, as: :json
+    end
+
+    assert_response 401
+  end
+
+  # DELETE /unfollow
   test "should destroy following" do
     assert_difference("Following.count", -1) do
       delete unfollow_user_url(@user, @following.target_id), headers: @header_user, as: :json
     end
 
     assert_response :success
+  end
+
+  test "should destroy following for other user for admin" do
+    assert_difference("Following.count", -1) do
+      delete unfollow_user_url(@user, @following.target_id), headers: @header_admin, as: :json
+    end
+
+    assert_response :success
+  end
+
+  test "should not destroy following for other user for normal user" do
+    assert_difference("Following.count", 0) do
+      delete unfollow_user_url(@user_admin, @following.target_id), headers: @header_user, as: :json
+    end
+
+    assert_response 401
+  end
+
+  test "should not destroy following if header invalid" do
+    assert_difference("Following.count", 0) do
+      delete unfollow_user_url(@user, @following.target_id), headers: @header_invalid, as: :json
+    end
+
+    assert_response 401
   end
 end

--- a/test/controllers/followings_controller_test.rb
+++ b/test/controllers/followings_controller_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+class FollowingsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    setup_user_auth
+    setup_admin_auth
+    setup_invalid_auth
+    @following = followings(:one)
+    @following_admin = followings(:two)
+  end
+
+  test "should get index of followings" do
+    get user_followings_url(@user), headers: @header_user, as: :json
+    assert_response :success
+  end
+
+  test "should get index of followers" do
+    get followers_user_url(@user), headers: @header_user, as: :json
+    assert_response :success
+  end
+
+  test "should create following" do
+    assert_difference("Following.count") do
+      post follow_user_url(@user, @following.target_id), headers: @header_user, as: :json
+    end
+
+    assert_response :created
+  end
+
+  test "should destroy following" do
+    assert_difference("Following.count", -1) do
+      delete unfollow_user_url(@user, @following.target_id), headers: @header_user, as: :json
+    end
+
+    assert_response :success
+  end
+end

--- a/test/controllers/followings_controller_test.rb
+++ b/test/controllers/followings_controller_test.rb
@@ -6,7 +6,6 @@ class FollowingsControllerTest < ActionDispatch::IntegrationTest
     setup_admin_auth
     setup_invalid_auth
     @following = followings(:one)
-    @following_admin = followings(:two)
   end
 
   test "should get index of followings" do
@@ -21,7 +20,7 @@ class FollowingsControllerTest < ActionDispatch::IntegrationTest
 
   test "should create following" do
     assert_difference("Following.count") do
-      post follow_user_url(@user, @following.target_id), headers: @header_user, as: :json
+      post follow_user_url(@user_admin, @user.id), headers: @header_admin, as: :json
     end
 
     assert_response :created

--- a/test/fixtures/followings.yml
+++ b/test/fixtures/followings.yml
@@ -3,7 +3,3 @@
 one:
   user: one
   target: two
-
-two:
-  user: two
-  target: one

--- a/test/fixtures/followings.yml
+++ b/test/fixtures/followings.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  target: two
+
+two:
+  user: two
+  target: one

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -11,3 +11,9 @@ two:
   name: myname2
   admin: true
   password_digest: $2a$14$yWjcGVzgVVBZHQV377NA2.R9.Uf7NPoBoHMsBaPboh552vuxhQV06
+
+three:
+  email: mytest3@email.com
+  name: myname3
+  admin: false
+  password_digest: $2a$14$yWjcGVzgVVBZHQV377NA2.R9.Uf7NPoBoHMsBaPboh552vuxhQV06

--- a/test/models/following_test.rb
+++ b/test/models/following_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class FollowingTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/following_test.rb
+++ b/test/models/following_test.rb
@@ -1,7 +1,35 @@
 require "test_helper"
 
 class FollowingTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  setup do
+    @user = users(:one)
+    @user_admin = users(:two)
+  end
+
+  test "should create following" do
+    @following = @user_admin.followings.build({ target_id: @user.id })
+    assert_difference("Following.count") do
+      @following.save
+    end
+
+    assert_equal 0, @following.errors.count
+  end
+
+  test "should not create following if the target user is the same as current user" do
+    @following = @user.followings.build({ target_id: @user.id })
+    assert_difference("Following.count", 0) do
+      @following.save
+    end
+
+    assert_equal 1, @following.errors.count
+  end
+
+  test "should not create following if the target user is already followed" do
+    @following = @user.followings.build({ target_id: @user_admin.id })
+    assert_difference("Following.count", 0) do
+      @following.save
+    end
+
+    assert_equal 1, @following.errors.count
+  end
 end


### PR DESCRIPTION
Major updates:
- Implement basic Followings APIs

All added APIs are protected:
- `POST /users/:user_id/follow/:target_id`
- `DELETE /users/:user_id/unfollow/:target_id`
- `GET /users/:user_id/followings`
- `GET /users/:user_id/followers`