### PR TITLE
Implement Clock-In sorting and enable manual clock-in/clock-out actions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,8 @@ gem "thruster", require: false
 
 gem "jwt"
 
+gem "pagy"
+
 group :development, :test do
   gem "dotenv"
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,6 +165,7 @@ GEM
     nokogiri (1.18.7-x86_64-linux-musl)
       racc (~> 1.4)
     ostruct (0.6.1)
+    pagy (9.3.4)
     parallel (1.26.3)
     parser (3.3.7.4)
       ast (~> 2.4.1)
@@ -301,6 +302,7 @@ DEPENDENCIES
   jbuilder
   jwt
   kamal
+  pagy
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 8.0.2)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,11 @@
 class ApplicationController < ActionController::API
+  include Pagy::Backend
+
   before_action :authenticate_user
+  after_action { pagy_headers_merge(@pagy) if @pagy }
 
   private
+
   def authenticate_user
     header = request.headers["Authorization"]
     token = header.split(" ").last if header

--- a/app/controllers/clock_ins_controller.rb
+++ b/app/controllers/clock_ins_controller.rb
@@ -8,7 +8,7 @@ class ClockInsController < ApplicationController
   # GET /users/1/clock_ins
   # GET /users/1/clock_ins.json
   def index
-    @pagy, @clock_ins = pagy(@user.clock_ins)
+    @pagy, @clock_ins = pagy(@user.clock_ins.order(clock_in_at: clock_in_sort_params))
   end
 
   # GET /users/1/clock_ins/1
@@ -69,5 +69,14 @@ class ClockInsController < ApplicationController
   # Only allow a list of trusted parameters through.
   def clock_in_params
     { user_id: params.expect(:user_id) }
+  end
+
+  def clock_in_sort_params
+    if params[:sort] == "asc"
+      :asc
+    else
+      # sort by latest clock ins by default
+      :desc
+    end
   end
 end

--- a/app/controllers/clock_ins_controller.rb
+++ b/app/controllers/clock_ins_controller.rb
@@ -8,7 +8,7 @@ class ClockInsController < ApplicationController
   # GET /users/1/clock_ins
   # GET /users/1/clock_ins.json
   def index
-    @clock_ins = @user.clock_ins
+    @pagy, @clock_ins = pagy(@user.clock_ins)
   end
 
   # GET /users/1/clock_ins/1

--- a/app/controllers/clock_ins_controller.rb
+++ b/app/controllers/clock_ins_controller.rb
@@ -1,7 +1,7 @@
 class ClockInsController < ApplicationController
   include Authorization
   before_action :set_user
-  before_action :set_clock_in, only: %i[ show destroy ]
+  before_action :set_clock_in, only: %i[ show destroy manual_update ]
 
   before_action :authorize_user
 
@@ -30,6 +30,7 @@ class ClockInsController < ApplicationController
     end
   end
 
+  # set clock out time to the latest sleep
   # PATCH /users/1/clock-out
   # PATCH /users/1/clock-out.json
   def update
@@ -41,6 +42,22 @@ class ClockInsController < ApplicationController
     else
       render json: @clock_in.errors, status: :unprocessable_entity
     end
+  end
+
+  # if user forgot to clock out on previous sleep session, they can manually set the clock out time on older clock ins data
+  # PATCH /users/1/clock-ins/1/clock-out
+  # PATCH /users/1/clock-ins/1/clock-out.json
+  def manual_update
+    clock_out_param_parsed = Time.zone.strptime(clock_out_param, "%Y-%m-%d %H:%M")
+    @clock_in.clock_out_at = clock_out_param_parsed
+    @clock_in.duration = @clock_in.clock_out_at - @clock_in.clock_in_at
+    if @clock_in.save
+      render :show, status: :ok
+    else
+      render json: @clock_in.errors, status: :unprocessable_entity
+    end
+  rescue ArgumentError
+    render json: { error: "Time format must be YYYY-MM-DD HH:MM" }, status: :unprocessable_entity
   end
 
   # DELETE /users/1/clock_ins/1
@@ -69,6 +86,10 @@ class ClockInsController < ApplicationController
   # Only allow a list of trusted parameters through.
   def clock_in_params
     { user_id: params.expect(:user_id) }
+  end
+
+  def clock_out_param
+    params.expect(:clock_out_at)
   end
 
   def clock_in_sort_params

--- a/app/controllers/followings_controller.rb
+++ b/app/controllers/followings_controller.rb
@@ -7,13 +7,13 @@ class FollowingsController < ApplicationController
   # GET /followings
   # GET /followings.json
   def index
-    @followings = @user.followings
+    @pagy, @followings = pagy(@user.followings)
   end
 
   # GET /followers
   # GET /followers.json
   def followers
-    @followings = @user.followers
+    @pagy, @followings = pagy(@user.followers)
     render :index, status: :ok
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,7 +10,7 @@ class UsersController < ApplicationController
   # GET /users.json
   def index
     if @current_user.admin?
-      @users = User.all
+      @pagy, @users = pagy(User.all)
       render json: @users
     else
       render json: { error: "Unauthorized" }, status: :unauthorized

--- a/app/models/clock_in.rb
+++ b/app/models/clock_in.rb
@@ -1,3 +1,24 @@
 class ClockIn < ApplicationRecord
   belongs_to :user
+
+  validate :correct_timing
+
+  def correct_timing
+    now = Time.now + 1.minute
+    if clock_in_at.present? && clock_in_at > now
+      errors.add(:clock_in_at, "Clock in time must be in the past")
+    end
+
+    if clock_out_at.present? && clock_out_at > now
+      errors.add(:clock_out_at, "Clock out time must be in the past")
+    end
+
+    if !clock_in_at.present? && clock_out_at.present?
+      errors.add(:clock_in_at, "Missing clock_in_at")
+    end
+
+    if clock_in_at.present? && clock_out_at.present? && clock_in_at > clock_out_at
+      errors.add(:clock_out_at, "Clock out time must come after clock in time")
+    end
+  end
 end

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -73,7 +73,7 @@
 
 # Headers extra: http response headers (and other helpers) useful for API pagination
 # See https://ddnexus.github.io/pagy/docs/extras/headers
-require 'pagy/extras/headers'
+require "pagy/extras/headers"
 # Pagy::DEFAULT[:headers] = { page: 'Current-Page',
 #                            limit: 'Page-Items',
 #                            count: 'Total-Count',

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,0 +1,220 @@
+# frozen_string_literal: true
+
+# Pagy initializer file (9.3.3)
+# Customize only what you really need and notice that the core Pagy works also without any of the following lines.
+# Should you just cherry pick part of this file, please maintain the require-order of the extras
+
+
+# Pagy Variables
+# See https://ddnexus.github.io/pagy/docs/api/pagy#variables
+# You can set any pagy variable as a Pagy::DEFAULT. They can also be overridden per instance by just passing them to
+# Pagy.new|Pagy::Countless.new|Pagy::Calendar::*.new or any of the #pagy* controller methods
+# Here are the few that make more sense as DEFAULTs:
+# Pagy::DEFAULT[:limit]       = 20                    # default
+# Pagy::DEFAULT[:size]        = 7                     # default
+# Pagy::DEFAULT[:ends]        = true                  # default
+# Pagy::DEFAULT[:page_param]  = :page                 # default
+# Pagy::DEFAULT[:count_args]  = []                    # example for non AR ORMs
+# Pagy::DEFAULT[:max_pages]   = 3000                  # example
+
+
+# Extras
+# See https://ddnexus.github.io/pagy/categories/extra
+
+
+# Legacy Compatibility Extras
+
+# Size extra: Enable the Array type for the `:size` variable (e.g. `size: [1,4,4,1]`)
+# See https://ddnexus.github.io/pagy/docs/extras/size
+# require 'pagy/extras/size'   # must be required before the other extras
+
+
+# Backend Extras
+
+# Arel extra: For better performance utilizing grouped ActiveRecord collections:
+# See: https://ddnexus.github.io/pagy/docs/extras/arel
+# require 'pagy/extras/arel'
+
+# Array extra: Paginate arrays efficiently, avoiding expensive array-wrapping and without overriding
+# See https://ddnexus.github.io/pagy/docs/extras/array
+# require 'pagy/extras/array'
+
+# Calendar extra: Add pagination filtering by calendar time unit (year, quarter, month, week, day)
+# See https://ddnexus.github.io/pagy/docs/extras/calendar
+# require 'pagy/extras/calendar'
+# Default for each calendar unit class in IRB:
+# >> Pagy::Calendar::Year::DEFAULT
+# >> Pagy::Calendar::Quarter::DEFAULT
+# >> Pagy::Calendar::Month::DEFAULT
+# >> Pagy::Calendar::Week::DEFAULT
+# >> Pagy::Calendar::Day::DEFAULT
+#
+# Uncomment the following lines, if you need calendar localization without using the I18n extra
+# module LocalizePagyCalendar
+#   def localize(time, opts)
+#     ::I18n.l(time, **opts)
+#   end
+# end
+# Pagy::Calendar.prepend LocalizePagyCalendar
+
+# Countless extra: Paginate without any count, saving one query per rendering
+# See https://ddnexus.github.io/pagy/docs/extras/countless
+# require 'pagy/extras/countless'
+# Pagy::DEFAULT[:countless_minimal] = false   # default (eager loading)
+
+# Elasticsearch Rails extra: Paginate `ElasticsearchRails::Results` objects
+# See https://ddnexus.github.io/pagy/docs/extras/elasticsearch_rails
+# Default :pagy_search method: change only if you use also
+# the searchkick or meilisearch extra that defines the same
+# Pagy::DEFAULT[:elasticsearch_rails_pagy_search] = :pagy_search
+# Default original :search method called internally to do the actual search
+# Pagy::DEFAULT[:elasticsearch_rails_search] = :search
+# require 'pagy/extras/elasticsearch_rails'
+
+# Headers extra: http response headers (and other helpers) useful for API pagination
+# See https://ddnexus.github.io/pagy/docs/extras/headers
+require 'pagy/extras/headers'
+# Pagy::DEFAULT[:headers] = { page: 'Current-Page',
+#                            limit: 'Page-Items',
+#                            count: 'Total-Count',
+#                            pages: 'Total-Pages' }     # default
+
+# Keyset extra: Paginate with the Pagy keyset pagination technique
+# See https://ddnexus.github.io/pagy/docs/extras/keyset
+# require 'pagy/extras/keyset'
+
+# Meilisearch extra: Paginate `Meilisearch` result objects
+# See https://ddnexus.github.io/pagy/docs/extras/meilisearch
+# Default :pagy_search method: change only if you use also
+# the elasticsearch_rails or searchkick extra that define the same method
+# Pagy::DEFAULT[:meilisearch_pagy_search] = :pagy_search
+# Default original :search method called internally to do the actual search
+# Pagy::DEFAULT[:meilisearch_search] = :ms_search
+# require 'pagy/extras/meilisearch'
+
+# Metadata extra: Provides the pagination metadata to Javascript frameworks like Vue.js, react.js, etc.
+# See https://ddnexus.github.io/pagy/docs/extras/metadata
+# you must require the JS Tools internal extra (BEFORE the metadata extra) ONLY if you need also the :sequels
+# require 'pagy/extras/js_tools'
+# require 'pagy/extras/metadata'
+# For performance reasons, you should explicitly set ONLY the metadata you use in the frontend
+# Pagy::DEFAULT[:metadata] = %i[scaffold_url page prev next last]   # example
+
+# Searchkick extra: Paginate `Searchkick::Results` objects
+# See https://ddnexus.github.io/pagy/docs/extras/searchkick
+# Default :pagy_search method: change only if you use also
+# the elasticsearch_rails or meilisearch extra that defines the same
+# Pagy::DEFAULT[:searchkick_pagy_search] = :pagy_search
+# Default original :search method called internally to do the actual search
+# Pagy::DEFAULT[:searchkick_search] = :search
+# require 'pagy/extras/searchkick'
+# uncomment if you are going to use Searchkick.pagy_search
+# Searchkick.extend Pagy::Searchkick
+
+
+# Frontend Extras
+
+# Bootstrap extra: Add nav, nav_js and combo_nav_js helpers and templates for Bootstrap pagination
+# See https://ddnexus.github.io/pagy/docs/extras/bootstrap
+# require 'pagy/extras/bootstrap'
+
+# Bulma extra: Add nav, nav_js and combo_nav_js helpers and templates for Bulma pagination
+# See https://ddnexus.github.io/pagy/docs/extras/bulma
+# require 'pagy/extras/bulma'
+
+# Pagy extra: Add the pagy styled versions of the javascript-powered navs
+# and a few other components to the Pagy::Frontend module.
+# See https://ddnexus.github.io/pagy/docs/extras/pagy
+# require 'pagy/extras/pagy'
+
+# Multi size var used by the *_nav_js helpers
+# See https://ddnexus.github.io/pagy/docs/extras/pagy#steps
+# Pagy::DEFAULT[:steps] = { 0 => 5, 540 => 7, 720 => 9 }   # example
+
+
+# Feature Extras
+
+# Gearbox extra: Automatically change the limit per page depending on the page number
+# See https://ddnexus.github.io/pagy/docs/extras/gearbox
+# require 'pagy/extras/gearbox'
+# set to false only if you want to make :gearbox_extra an opt-in variable
+# Pagy::DEFAULT[:gearbox_extra] = false               # default true
+# Pagy::DEFAULT[:gearbox_limit] = [15, 30, 60, 100]   # default
+
+# Limit extra: Allow the client to request a custom limit per page with an optional selector UI
+# See https://ddnexus.github.io/pagy/docs/extras/limit
+# require 'pagy/extras/limit'
+# set to false only if you want to make :limit_extra an opt-in variable
+# Pagy::DEFAULT[:limit_extra] = false    # default true
+# Pagy::DEFAULT[:limit_param] = :limit   # default
+# Pagy::DEFAULT[:limit_max]   = 100      # default
+
+# Overflow extra: Allow for easy handling of overflowing pages
+# See https://ddnexus.github.io/pagy/docs/extras/overflow
+# require 'pagy/extras/overflow'
+# Pagy::DEFAULT[:overflow] = :empty_page    # default  (other options: :last_page and :exception)
+
+# Trim extra: Remove the page=1 param from links
+# See https://ddnexus.github.io/pagy/docs/extras/trim
+# require 'pagy/extras/trim'
+# set to false only if you want to make :trim_extra an opt-in variable
+# Pagy::DEFAULT[:trim_extra] = false # default true
+
+# Standalone extra: Use pagy in non Rack environment/gem
+# See https://ddnexus.github.io/pagy/docs/extras/standalone
+# require 'pagy/extras/standalone'
+# Pagy::DEFAULT[:url] = 'http://www.example.com/subdir'  # optional default
+
+# Jsonapi extra: Implements JSON:API specifications
+# See https://ddnexus.github.io/pagy/docs/extras/jsonapi
+# require 'pagy/extras/jsonapi'   # must be required after the other extras
+# set to false only if you want to make :jsonapi an opt-in variable
+# Pagy::DEFAULT[:jsonapi] = false  # default true
+
+# Rails
+# Enable the .js file required by the helpers that use javascript
+# (pagy*_nav_js, pagy*_combo_nav_js, and pagy_limit_selector_js)
+# See https://ddnexus.github.io/pagy/docs/api/javascript
+
+# With the asset pipeline
+# Sprockets need to look into the pagy javascripts dir, so add it to the assets paths
+# Rails.application.config.assets.paths << Pagy.root.join('javascripts')
+
+# I18n
+
+# Pagy internal I18n: ~18x faster using ~10x less memory than the i18n gem
+# See https://ddnexus.github.io/pagy/docs/api/i18n
+# Notice: No need to configure anything in this section if your app uses only "en"
+# or if you use the i18n extra below
+#
+# Examples:
+# load the "de" built-in locale:
+# Pagy::I18n.load(locale: 'de')
+#
+# load the "de" locale defined in the custom file at :filepath:
+# Pagy::I18n.load(locale: 'de', filepath: 'path/to/pagy-de.yml')
+#
+# load the "de", "en" and "es" built-in locales:
+# (the first passed :locale will be used also as the default_locale)
+# Pagy::I18n.load({ locale: 'de' },
+#                 { locale: 'en' },
+#                 { locale: 'es' })
+#
+# load the "en" built-in locale, a custom "es" locale,
+# and a totally custom locale complete with a custom :pluralize proc:
+# (the first passed :locale will be used also as the default_locale)
+# Pagy::I18n.load({ locale: 'en' },
+#                 { locale: 'es', filepath: 'path/to/pagy-es.yml' },
+#                 { locale: 'xyz',  # not built-in
+#                   filepath: 'path/to/pagy-xyz.yml',
+#                   pluralize: lambda{ |count| ... } )
+
+
+# I18n extra: uses the standard i18n gem which is ~18x slower using ~10x more memory
+# than the default pagy internal i18n (see above)
+# See https://ddnexus.github.io/pagy/docs/extras/i18n
+# require 'pagy/extras/i18n'
+
+
+# When you are done setting your own default freeze it, so it will not get changed accidentally
+Pagy::DEFAULT.freeze

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,9 @@ Rails.application.routes.draw do
   post "sessions/create"
   resources :users do
     patch "clock-out" => "clock_ins#update", on: :member
-    resources :clock_ins, path: "clock-ins", except: [ :update ]
+    resources :clock_ins, path: "clock-ins", except: [ :update ] do
+      patch "clock-out" => "clock_ins#manual_update", on: :member
+    end
     resources :followings, only: [ :index ]
     post "follow/:target_id" => "followings#create", on: :member, as: "follow"
     get "followers" => "followings#followers", on: :member

--- a/test/controllers/clock_ins_controller_test.rb
+++ b/test/controllers/clock_ins_controller_test.rb
@@ -105,6 +105,32 @@ class ClockInsControllerTest < ActionDispatch::IntegrationTest
     assert_response 401
   end
 
+  # PATCH /users/1/clock-ins/1/clock-out
+  test "should perform manual clock out" do
+    patch clock_out_user_clock_in_url(@user, @clock_in), params: { clock_out_at: "2025-04-14 10:11" }, headers: @header_user, as: :json
+    assert_response :success
+  end
+
+  test "should perform manual clock out for other user for admin" do
+    patch clock_out_user_clock_in_url(@user, @clock_in), params: { clock_out_at: "2025-04-14 10:11" }, headers: @header_admin, as: :json
+    assert_response :success
+  end
+
+  test "should not perform manual clock out if param invalid" do
+    patch clock_out_user_clock_in_url(@user, @clock_in), params: { clock_out_at: "2025-04-14" }, headers: @header_admin, as: :json
+    assert_response 422
+  end
+
+  test "should not perform manual clock out for other user for normal user" do
+    patch clock_out_user_clock_in_url(@user_admin, @clock_in_admin), params: { clock_out_at: "2025-04-14 10:11" }, headers: @header_user, as: :json
+    assert_response 401
+  end
+
+  test "should not perform manual clock out for other user if header invalid" do
+    patch clock_out_user_clock_in_url(@user, @clock_in), params: { clock_out_at: "2025-04-14 10:11" }, headers: @header_invalid, as: :json
+    assert_response 401
+  end
+
   # DELETE /users/1/clock_ins/1
   test "should destroy clock_in" do
     assert_difference("ClockIn.count", -1) do

--- a/test/controllers/clock_ins_controller_test.rb
+++ b/test/controllers/clock_ins_controller_test.rb
@@ -7,6 +7,9 @@ class ClockInsControllerTest < ActionDispatch::IntegrationTest
     setup_invalid_auth
     @clock_in = clock_ins(:one)
     @clock_in_admin = clock_ins(:two)
+
+    @clock_out_at = (@clock_in.clock_in_at + 1.minute).strftime("%Y-%m-%d %H:%M")
+    @clock_out_at_admin = (@clock_in_admin.clock_in_at + 1.minute).strftime("%Y-%m-%d %H:%M")
   end
 
   # GET /users/1/clock_ins
@@ -131,27 +134,27 @@ class ClockInsControllerTest < ActionDispatch::IntegrationTest
 
   # PATCH /users/1/clock-ins/1/clock-out
   test "should perform manual clock out" do
-    patch clock_out_user_clock_in_url(@user, @clock_in), params: { clock_out_at: "2025-04-14 10:11" }, headers: @header_user, as: :json
+    patch clock_out_user_clock_in_url(@user, @clock_in), params: { clock_out_at: @clock_out_at }, headers: @header_user, as: :json
     assert_response :success
   end
 
   test "should perform manual clock out for other user for admin" do
-    patch clock_out_user_clock_in_url(@user, @clock_in), params: { clock_out_at: "2025-04-14 10:11" }, headers: @header_admin, as: :json
+    patch clock_out_user_clock_in_url(@user, @clock_in), params: { clock_out_at: @clock_out_at }, headers: @header_admin, as: :json
     assert_response :success
   end
 
   test "should not perform manual clock out if param invalid" do
-    patch clock_out_user_clock_in_url(@user, @clock_in), params: { clock_out_at: "2025-04-14" }, headers: @header_admin, as: :json
+    patch clock_out_user_clock_in_url(@user, @clock_in), params: { clock_out_at: "2025-11-11" }, headers: @header_admin, as: :json
     assert_response 422
   end
 
   test "should not perform manual clock out for other user for normal user" do
-    patch clock_out_user_clock_in_url(@user_admin, @clock_in_admin), params: { clock_out_at: "2025-04-14 10:11" }, headers: @header_user, as: :json
+    patch clock_out_user_clock_in_url(@user_admin, @clock_in_admin), params: { clock_out_at: @clock_out_at_admin }, headers: @header_user, as: :json
     assert_response 401
   end
 
   test "should not perform manual clock out for other user if header invalid" do
-    patch clock_out_user_clock_in_url(@user, @clock_in), params: { clock_out_at: "2025-04-14 10:11" }, headers: @header_invalid, as: :json
+    patch clock_out_user_clock_in_url(@user, @clock_in), params: { clock_out_at: @clock_out_at }, headers: @header_invalid, as: :json
     assert_response 401
   end
 

--- a/test/controllers/clock_ins_controller_test.rb
+++ b/test/controllers/clock_ins_controller_test.rb
@@ -47,6 +47,30 @@ class ClockInsControllerTest < ActionDispatch::IntegrationTest
     assert_response :created
   end
 
+  test "should perform manual clock in" do
+    assert_difference("ClockIn.count") do
+      post user_clock_ins_url(@user), params: { clock_in_at: "2025-04-14 10:11" }, headers: @header_user, as: :json
+    end
+
+    assert_response :created
+  end
+
+  test "should perform manual clock in for other user for admin" do
+    assert_difference("ClockIn.count") do
+      post user_clock_ins_url(@user), params: { clock_in_at: "2025-04-14 10:11" }, headers: @header_admin, as: :json
+    end
+
+    assert_response :created
+  end
+
+  test "should not perform manual clock in if param invalid" do
+    assert_difference("ClockIn.count", 0) do
+      post user_clock_ins_url(@user), params: { clock_in_at: "2025-04-14" }, headers: @header_admin, as: :json
+    end
+
+    assert_response 422
+  end
+
   test "should not create clock_in for other user for normal user" do
     assert_difference("ClockIn.count", 0) do
       post user_clock_ins_url(@user_admin), headers: @header_user, params: { user_id: @clock_in_admin.user_id }, as: :json

--- a/test/models/clock_in_test.rb
+++ b/test/models/clock_in_test.rb
@@ -1,7 +1,53 @@
 require "test_helper"
 
 class ClockInTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  setup do
+    @user = users(:one)
+    @user_admin = users(:two)
+  end
+
+  test "should create clock in" do
+    @clock_in = @user.clock_ins.build({ clock_in_at: Time.now })
+    assert_difference("ClockIn.count") do
+      @clock_in.save
+    end
+
+    assert_equal 0, @clock_in.errors.count
+  end
+
+  test "should not create clock in if clock_in_at is in the future" do
+    @clock_in = @user.clock_ins.build({ clock_in_at: Time.now + 1.day })
+    assert_difference("ClockIn.count", 0) do
+      @clock_in.save
+    end
+
+    assert_equal 1, @clock_in.errors.count
+  end
+
+  test "should not create clock in if clock_in_at is missing while clock_out_at is present" do
+    @clock_in = @user.clock_ins.build({ clock_out_at: Time.now })
+    assert_difference("ClockIn.count", 0) do
+      @clock_in.save
+    end
+
+    assert_equal 1, @clock_in.errors.count
+  end
+
+  test "should not create clock in if clock_out_at is in the future" do
+    @clock_in = @user.clock_ins.build({ clock_in_at: Time.now, clock_out_at: Time.now + 1.day })
+    assert_difference("ClockIn.count", 0) do
+      @clock_in.save
+    end
+
+    assert_equal 1, @clock_in.errors.count
+  end
+
+  test "should not create clock in if clock_out_at is before clock_in_at" do
+    @clock_in = @user.clock_ins.build({ clock_in_at: Time.now - 1.day, clock_out_at: Time.now - 2.day })
+    assert_difference("ClockIn.count", 0) do
+      @clock_in.save
+    end
+
+    assert_equal 1, @clock_in.errors.count
+  end
 end


### PR DESCRIPTION
Major updates:
- Enable pagination and sort by `clock_in_at` descending (default) and ascending on endpoint `GET /users/:user_id/clock-ins`
- Enable manual `clock_in_at` input on endpoint `POST /users/:user_id/clock-ins`
- Add API `PATCH /users/:user_id/clock-ins/:clock-in-id/clock-out` to perform clock-out on the past sleep session

Minor updates:
- Enable pagination on these endpoints:
  - `GET /users/:user_id/followings`
  - `GET /users/:user_id/followers`
  - `GET /users`