### PR TITLE
Implement following users' clock-ins API

### DIFF
--- a/app/controllers/clock_ins_controller.rb
+++ b/app/controllers/clock_ins_controller.rb
@@ -7,10 +7,17 @@ class ClockInsController < ApplicationController
 
   TIME_FORMAT = "%Y-%m-%d %H:%M"
 
-  # GET /users/1/clock_ins
-  # GET /users/1/clock_ins.json
+  # GET /users/1/clock-ins
+  # GET /users/1/clock-ins.json
   def index
     @pagy, @clock_ins = pagy(@user.clock_ins.order(clock_in_at: clock_in_sort_params))
+  end
+
+  # GET /users/1/clock-ins/followings
+  # GET /users/1/clock-ins/followings.json
+  def followings
+    @pagy, @clock_ins = pagy(ClockIn.get_followings(@user, query_options))
+    render :index, status: :ok
   end
 
   # GET /users/1/clock_ins/1
@@ -98,6 +105,10 @@ class ClockInsController < ApplicationController
 
   def clock_out_param
     params.expect(:clock_out_at)
+  end
+
+  def query_options
+    params.permit(:exclude_unfinished, :duration_sort)
   end
 
   def clock_in_sort_params

--- a/app/controllers/followings_controller.rb
+++ b/app/controllers/followings_controller.rb
@@ -20,7 +20,7 @@ class FollowingsController < ApplicationController
   # POST /follow
   # POST /follow.json
   def create
-    @following = @user.followings.build(following_params)
+    @following = @user.active_relationships.build(following_params)
 
     if @following.save
       render :show, status: :created
@@ -53,7 +53,7 @@ class FollowingsController < ApplicationController
   end
 
   def set_following
-    @following = @user.followings.where(target_id: params.expect(:target_id)).first
+    @following = @user.active_relationships.where(target_id: params.expect(:target_id)).first
   end
 
   # Only allow a list of trusted parameters through.

--- a/app/models/clock_in.rb
+++ b/app/models/clock_in.rb
@@ -21,4 +21,22 @@ class ClockIn < ApplicationRecord
       errors.add(:clock_out_at, "Clock out time must come after clock in time")
     end
   end
+
+  def self.get_followings(user, options = {})
+    user_ids = user.followings.map(&:id)
+    query = {
+      user_id: user_ids,
+      clock_in_at: 7.days.ago...
+    }
+
+    if options[:exclude_unfinished]
+      query[:duration] = Range.new(1, nil)
+    end
+
+    duration_sort = :desc
+    if options[:duration_sort] == "asc"
+      duration_sort = :asc
+    end
+    clock_ins = ClockIn.where(query).order(duration: duration_sort)
+  end
 end

--- a/app/models/following.rb
+++ b/app/models/following.rb
@@ -7,7 +7,7 @@ class Following < ApplicationRecord
 
   def different_user
     if user_id == target_id
-      errors.add(:target_id, "Can't follow you own account")
+      errors.add(:target_id, "Can't follow your own account")
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,11 @@
 class User < ApplicationRecord
   has_secure_password
   has_many :clock_ins, dependent: :destroy
-  has_many :followers, foreign_key: "target_id", class_name: "Following", dependent: :destroy
-  has_many :followings, foreign_key: "user_id", class_name: "Following", dependent: :destroy
+
+  has_many :active_relationships, class_name: "Following", foreign_key: "user_id", dependent: :destroy, inverse_of: :user
+  has_many :followings, through: :active_relationships, source: :target
+  has_many :passive_relationships, class_name: "Following", foreign_key: "target_id", dependent: :destroy, inverse_of: :target
+  has_many :followers, through: :passive_relationships, source: :user
 
   validates :email, presence: true, uniqueness: true
   validates :password_digest, presence: true

--- a/app/views/followings/index.json.jbuilder
+++ b/app/views/followings/index.json.jbuilder
@@ -1,1 +1,1 @@
-json.array! @followings, partial: "followings/following", as: :following
+json.array! @followings, partial: "users/user", as: :user

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   resources :users do
     patch "clock-out" => "clock_ins#update", on: :member
     resources :clock_ins, path: "clock-ins", except: [ :update ] do
+      get "followings" => "clock_ins#followings", on: :collection
       patch "clock-out" => "clock_ins#manual_update", on: :member
     end
     resources :followings, only: [ :index ]

--- a/test/controllers/clock_ins_controller_test.rb
+++ b/test/controllers/clock_ins_controller_test.rb
@@ -33,6 +33,27 @@ class ClockInsControllerTest < ActionDispatch::IntegrationTest
     assert_response 401
   end
 
+  # GET /users/1/clock_ins/followings
+  test "should get followings" do
+    get followings_user_clock_ins_url(@user), headers: @header_user, as: :json
+    assert_response :success
+  end
+
+  test "should get followings from other user for admin" do
+    get followings_user_clock_ins_url(@user), headers: @header_admin, as: :json
+    assert_response :success
+  end
+
+  test "should not get followings from other user for normal user" do
+    get followings_user_clock_ins_url(@user_admin), headers: @header_user, as: :json
+    assert_response 401
+  end
+
+  test "should not get followings if header invalid" do
+    get followings_user_clock_ins_url(@user), headers: @header_invalid, as: :json
+    assert_response 401
+  end
+
   # POST /users/1/clock_in
   test "should create clock_in" do
     assert_difference("ClockIn.count") do

--- a/test/models/clock_in_test.rb
+++ b/test/models/clock_in_test.rb
@@ -50,4 +50,20 @@ class ClockInTest < ActiveSupport::TestCase
 
     assert_equal 1, @clock_in.errors.count
   end
+
+  test "should return followings" do
+    @clock_ins = ClockIn.get_followings(@user_admin)
+
+    assert_not_equal 0, @clock_ins
+  end
+
+  test "should return followings with options" do
+    options = {
+      exclude_unfinished: true,
+      duration_sort: "asc"
+    }
+    @clock_ins = ClockIn.get_followings(@user_admin, options)
+
+    assert_not_equal 0, @clock_ins
+  end
 end

--- a/test/models/following_test.rb
+++ b/test/models/following_test.rb
@@ -7,7 +7,7 @@ class FollowingTest < ActiveSupport::TestCase
   end
 
   test "should create following" do
-    @following = @user_admin.followings.build({ target_id: @user.id })
+    @following = @user_admin.active_relationships.build({ target_id: @user.id })
     assert_difference("Following.count") do
       @following.save
     end
@@ -16,7 +16,7 @@ class FollowingTest < ActiveSupport::TestCase
   end
 
   test "should not create following if the target user is the same as current user" do
-    @following = @user.followings.build({ target_id: @user.id })
+    @following = @user.active_relationships.build({ target_id: @user.id })
     assert_difference("Following.count", 0) do
       @following.save
     end
@@ -25,7 +25,7 @@ class FollowingTest < ActiveSupport::TestCase
   end
 
   test "should not create following if the target user is already followed" do
-    @following = @user.followings.build({ target_id: @user_admin.id })
+    @following = @user.active_relationships.build({ target_id: @user_admin.id })
     assert_difference("Following.count", 0) do
       @following.save
     end


### PR DESCRIPTION
Major updates:
- Implement endpoint `GET /users/:user_id/clock-ins/followings` to retrieve all following users' sleep
records from the last 7 days
- Fix user following relationship to better support the API

Minor updates:
- Fix typo on follow action error message
