### PR TITLE
Refactor API responses

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,12 @@ class ApplicationController < ActionController::API
   before_action :authenticate_user
   after_action { pagy_headers_merge(@pagy) if @pagy }
 
+  def render_error(error, http_status)
+    @error = error
+    @http_status = Rack::Utils.status_code(http_status)
+    render "errors/error", status: http_status
+  end
+
   private
 
   def authenticate_user
@@ -13,7 +19,7 @@ class ApplicationController < ActionController::API
     if decoded
       @current_user = User.find_by(id: decoded[:user_id])
     else
-      render json: { error: "Unauthorized" }, status: :unauthorized
+      render_error("Unauthorized", :unauthorized)
     end
   end
 end

--- a/app/controllers/clock_ins_controller.rb
+++ b/app/controllers/clock_ins_controller.rb
@@ -39,10 +39,10 @@ class ClockInsController < ApplicationController
     if @clock_in.save
       render :show, status: :created
     else
-      render json: @clock_in.errors, status: :unprocessable_entity
+      render_error(@clock_in.errors, :unprocessable_entity)
     end
   rescue ArgumentError
-    render json: { error: "Time format must be YYYY-MM-DD HH:MM" }, status: :unprocessable_entity
+    render_error("Time format must be YYYY-MM-DD HH:MM", :unprocessable_entity)
   end
 
   # set clock out time to the latest sleep
@@ -55,7 +55,7 @@ class ClockInsController < ApplicationController
     if @clock_in.save
       render :show, status: :ok
     else
-      render json: @clock_in.errors, status: :unprocessable_entity
+      render_error(@clock_in.errors, :unprocessable_entity)
     end
   end
 
@@ -69,10 +69,10 @@ class ClockInsController < ApplicationController
     if @clock_in.save
       render :show, status: :ok
     else
-      render json: @clock_in.errors, status: :unprocessable_entity
+      render_error(@clock_in.errors, :unprocessable_entity)
     end
   rescue ArgumentError
-    render json: { error: "Time format must be YYYY-MM-DD HH:MM" }, status: :unprocessable_entity
+    render_error("Time format must be YYYY-MM-DD HH:MM", :unprocessable_entity)
   end
 
   # DELETE /users/1/clock_ins/1

--- a/app/controllers/followings_controller.rb
+++ b/app/controllers/followings_controller.rb
@@ -25,7 +25,7 @@ class FollowingsController < ApplicationController
     if @following.save
       render :show, status: :created
     else
-      render json: @following.errors, status: :unprocessable_entity
+      render_error(@following.errors, :unprocessable_entity)
     end
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,7 +9,7 @@ class SessionsController < ApplicationController
       @token = Authentication.encode_jwt_token(user_id: @user.id)
       render :create, status: :created
     else
-      render json: { error: "Invalid credentials" }, status: :unauthorized
+      render_error("Invalid credentials", :unauthorized)
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,7 +13,7 @@ class UsersController < ApplicationController
       @pagy, @users = pagy(User.all)
       render json: @users
     else
-      render json: { error: "Unauthorized" }, status: :unauthorized
+      render_error("Unauthorized", :unauthorized)
     end
   end
 
@@ -32,7 +32,7 @@ class UsersController < ApplicationController
       @token = Authentication.encode_jwt_token(user_id: @user.id)
       render :create, status: :created
     else
-      render json: @user.errors, status: :unprocessable_entity
+      render_error(@user.errors, :unprocessable_entity)
     end
   end
 
@@ -42,7 +42,7 @@ class UsersController < ApplicationController
     if @user.update(user_params)
       render :show, status: :ok, location: @user
     else
-      render json: @user.errors, status: :unprocessable_entity
+      render_error(@user.errors, :unprocessable_entity)
     end
   end
 
@@ -53,7 +53,7 @@ class UsersController < ApplicationController
       @user.destroy!
       render json: { message: "OK" }, status: :ok
     else
-      render json: { error: "Unauthorized" }, status: :unauthorized
+      render_error("Unauthorized", :unauthorized)
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,7 +11,7 @@ class UsersController < ApplicationController
   def index
     if @current_user.admin?
       @pagy, @users = pagy(User.all)
-      render json: @users
+      render :index, status: :ok
     else
       render_error("Unauthorized", :unauthorized)
     end

--- a/app/views/clock_ins/index.json.jbuilder
+++ b/app/views/clock_ins/index.json.jbuilder
@@ -1,1 +1,3 @@
-json.array! @clock_ins, partial: "clock_ins/clock_in", as: :clock_in
+json.data do
+  json.array! @clock_ins, partial: "clock_ins/clock_in", as: :clock_in
+end

--- a/app/views/errors/error.json.jbuilder
+++ b/app/views/errors/error.json.jbuilder
@@ -1,0 +1,2 @@
+json.status @http_status
+json.error @error

--- a/app/views/followings/index.json.jbuilder
+++ b/app/views/followings/index.json.jbuilder
@@ -1,1 +1,3 @@
-json.array! @followings, partial: "users/user", as: :user
+json.data do
+  json.array! @followings, partial: "users/user", as: :user
+end

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,1 +1,3 @@
-json.array! @users, partial: "users/user", as: :user
+json.data do
+  json.array! @users, partial: "users/user", as: :user
+end


### PR DESCRIPTION
- Use consistent response format for error response. This affects all APIs
- Wrap array response in `data` key. Affected APIs:
  - `GET /users/:user_id/followings`
  - `GET /users/:user_id/followers`
  - `GET /users`
  -  `GET /users/:user_id/clock-ins`
  - `GET /users/:user_id/clock-ins/followers`