### PR TITLE
Update API responses and handle edge cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Simple API-only Ruby on Rails application to let users track when they go to bed
 ## Endpoints
 
 See the endpoints served by Goodnite in this [Postman](https://www.postman.com/) collection
+- [Goodnite.postman_collection.json](https://github.com/user-attachments/files/19758578/Goodnite.postman_collection.json)
 - [Goodnite Local.postman_environment.json](https://github.com/user-attachments/files/19753864/Goodnite.Local.postman_environment.json)
-- [Goodnite.postman_collection.json](https://github.com/user-attachments/files/19753868/Goodnite.postman_collection.json)
 
 
 ## Technical Guidelines

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Simple API-only Ruby on Rails application to let users track when they go to bed
 ## Endpoints
 
 See the endpoints served by Goodnite in this [Postman](https://www.postman.com/) collection
-- [Goodnite.postman_collection.json](https://github.com/user-attachments/files/19758578/Goodnite.postman_collection.json)
+- [Goodnite.postman_collection.json](https://github.com/user-attachments/files/19767511/Goodnite.postman_collection.json)
 - [Goodnite Local.postman_environment.json](https://github.com/user-attachments/files/19753864/Goodnite.Local.postman_environment.json)
 
 
@@ -39,17 +39,12 @@ These steps only need to be done once.
 ```shell
 git clone git@github.com:inassjunus/goodnite.git
 ```
-2. Install dependencies
-```shell
-make prepare
-```
-3. Make sure PostgreSQL is already running.
+2. Make sure PostgreSQL is already running.
 
 ```shell
 # check for postgres
 psql postgres
 ```
-
 If they haven't, run them.
 ```shell
 # starting redis in macOSX
@@ -57,7 +52,7 @@ brew services start postgresql
 ```
 Check the respective guidelines to find the right command for your local machine.
 
-4. Setup the database tables on PostgreSQL
+3. Setup the database tables on PostgreSQL
 ```sh
 # open PostgreSQL CLI
 psql postgres
@@ -83,29 +78,29 @@ CREATE DATABASE goodnite_test;
 
 Exit the postgreSQL CLI when you are done
 
-5. Install gems
+4. Install gems
 ```sh
 gem install bundler
 bundle install
 ```
 
-6. Run rails db migration
+5. Run rails db migration
 ```sh
 bin/rails db:migrate
 ```
 
-7. Copy env.sample, then adjust the values with the your own environment details
+6. Copy env.sample, then adjust the values with the your own environment details
 ```shell
 cp env.sample .env
 ```
 Please double check that the database values are correct
 
-8. [OPTIONAL] Initialize app data
+7. [OPTIONAL] Initialize app data
 ```sh
-# with default limit, each limit is 20 by default
+# initlalize with default limit, each limit is 20 by default
 bin/rails db:seed
 
-# with custom data limit
+# initlalize with custom data limit
 bin/rails db:seed seed_user_limit=2 seed_clock_in_limit=1 seed_following_limit=1
 ```
 

--- a/app/controllers/clock_ins_controller.rb
+++ b/app/controllers/clock_ins_controller.rb
@@ -50,6 +50,10 @@ class ClockInsController < ApplicationController
   # PATCH /users/1/clock-out.json
   def update
     @clock_in = @user.clock_ins.last
+    if !@clock_in.present?
+      render_error("You haven't clock-in yet", :unprocessable_entity)
+      return
+    end
     @clock_in.clock_out_at = Time.now
     @clock_in.duration = @clock_in.clock_out_at - @clock_in.clock_in_at
     if @clock_in.save

--- a/app/views/clock_ins/_clock_in.json.jbuilder
+++ b/app/views/clock_ins/_clock_in.json.jbuilder
@@ -1,2 +1,1 @@
 json.extract! clock_in, :id, :user_id, :duration, :clock_in_at, :clock_out_at, :created_at, :updated_at
-json.url user_clock_in_url(@user, clock_in, format: :json)

--- a/app/views/followings/index.json.jbuilder
+++ b/app/views/followings/index.json.jbuilder
@@ -1,3 +1,3 @@
 json.data do
-  json.array! @followings, partial: "users/user", as: :user
+  json.array! @followings, partial: "users/user_public", as: :user
 end

--- a/app/views/users/_user.json.jbuilder
+++ b/app/views/users/_user.json.jbuilder
@@ -1,2 +1,1 @@
 json.extract! user, :id, :email, :name, :admin, :created_at, :updated_at
-json.url user_url(user, format: :json)

--- a/app/views/users/_user_public.json.jbuilder
+++ b/app/views/users/_user_public.json.jbuilder
@@ -1,0 +1,1 @@
+json.extract! user, :id, :name

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -143,16 +143,16 @@ require "pagy/extras/headers"
 
 # Limit extra: Allow the client to request a custom limit per page with an optional selector UI
 # See https://ddnexus.github.io/pagy/docs/extras/limit
-# require 'pagy/extras/limit'
+require 'pagy/extras/limit'
 # set to false only if you want to make :limit_extra an opt-in variable
 # Pagy::DEFAULT[:limit_extra] = false    # default true
-# Pagy::DEFAULT[:limit_param] = :limit   # default
+Pagy::DEFAULT[:limit_param] = :limit   # default
 # Pagy::DEFAULT[:limit_max]   = 100      # default
 
 # Overflow extra: Allow for easy handling of overflowing pages
 # See https://ddnexus.github.io/pagy/docs/extras/overflow
-# require 'pagy/extras/overflow'
-# Pagy::DEFAULT[:overflow] = :empty_page    # default  (other options: :last_page and :exception)
+require 'pagy/extras/overflow'
+Pagy::DEFAULT[:overflow] = :empty_page    # default  (other options: :last_page and :exception)
 
 # Trim extra: Remove the page=1 param from links
 # See https://ddnexus.github.io/pagy/docs/extras/trim

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -143,7 +143,7 @@ require "pagy/extras/headers"
 
 # Limit extra: Allow the client to request a custom limit per page with an optional selector UI
 # See https://ddnexus.github.io/pagy/docs/extras/limit
-require 'pagy/extras/limit'
+require "pagy/extras/limit"
 # set to false only if you want to make :limit_extra an opt-in variable
 # Pagy::DEFAULT[:limit_extra] = false    # default true
 Pagy::DEFAULT[:limit_param] = :limit   # default
@@ -151,7 +151,7 @@ Pagy::DEFAULT[:limit_param] = :limit   # default
 
 # Overflow extra: Allow for easy handling of overflowing pages
 # See https://ddnexus.github.io/pagy/docs/extras/overflow
-require 'pagy/extras/overflow'
+require "pagy/extras/overflow"
 Pagy::DEFAULT[:overflow] = :empty_page    # default  (other options: :last_page and :exception)
 
 # Trim extra: Remove the page=1 param from links

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -65,6 +65,18 @@ def initialize_followings(user_ids, limit)
   end
 end
 
+admin_name = SecureRandom.base64(3)
+puts "Creating an admin user #{admin_name}"
+params = {
+  name: "user-#{admin_name}",
+  email: "admin-#{admin_name}@email.com",
+  password: "pass#{admin_name}",
+  admin: true,
+  password_confirmation: "pass#{admin_name}"
+}
+admin_user = User.create(params)
+admin_user.save
+
 user_limit = 20
 if ENV["seed_user_limit"]&.to_i.present?
   user_limit = ENV["seed_user_limit"].to_i

--- a/test/controllers/clock_ins_controller_test.rb
+++ b/test/controllers/clock_ins_controller_test.rb
@@ -4,6 +4,7 @@ class ClockInsControllerTest < ActionDispatch::IntegrationTest
   setup do
     setup_user_auth
     setup_admin_auth
+    setup_new_user_auth
     setup_invalid_auth
     @clock_in = clock_ins(:one)
     @clock_in_admin = clock_ins(:two)
@@ -134,23 +135,28 @@ class ClockInsControllerTest < ActionDispatch::IntegrationTest
 
   # PATCH /users/1/clock-out
   test "should perform clock out" do
-    patch clock_out_user_url(@user, @clock_in), headers: @header_user, as: :json
+    patch clock_out_user_url(@user), headers: @header_user, as: :json
     assert_response :success
   end
 
   test "should perform clock out for other user for admin" do
-    patch clock_out_user_url(@user, @clock_in), headers: @header_admin, as: :json
+    patch clock_out_user_url(@user), headers: @header_admin, as: :json
     assert_response :success
   end
 
   test "should not perform clock out for other user for normal user" do
-    patch clock_out_user_url(@user_admin, @clock_in), headers: @header_user, as: :json
+    patch clock_out_user_url(@user_admin), headers: @header_user, as: :json
     assert_response 401
   end
 
   test "should not perform clock out for other user if header invalid" do
     patch clock_out_user_url(@user, @clock_in), headers: @header_invalid, as: :json
     assert_response 401
+  end
+
+  test "should not perform clock out if user haven't clock-in yet" do
+    patch clock_out_user_url(@user_new), headers: @header_new_user, as: :json
+    assert_response 422
   end
 
   # PATCH /users/1/clock-ins/1/clock-out

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,6 +21,11 @@ module ActiveSupport
       @header_admin = setup_valid_auth(@user_admin)
     end
 
+    def setup_new_user_auth
+      @user_new = users(:three)
+      @header_new_user = setup_valid_auth(@user_new)
+    end
+
     def setup_valid_auth(user)
       token = Authentication.encode_jwt_token(user_id: user.id)
       header_admin = {


### PR DESCRIPTION
- Handle case when user is trying to clock out without performing a clock-in action in advance (e.g new user)
- Handle error when the given param `page` is overflowing
- Enable param `limit` on APIs that use pagination:
  - `GET /users/:user_id/followings`
  - `GET /users/:user_id/followers`
  - `GET /users`
  -  `GET /users/:user_id/clock-ins`
  - `GET /users/:user_id/clock-ins/followers`
- Update response to show only user's public info for these APIs:
   - `GET /users/:user_id/followings`
   - `GET /users/:user_id/followers`
- Remove field `url` from all data responses, since it is not used
- Update postman link on readme
