### PR TITLE
Refine handling on invalid API parameters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,8 @@ gem "jwt"
 
 gem "pagy"
 
+gem "email_validator"
+
 group :development, :test do
   gem "pry"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,8 @@ GEM
     dotenv (3.1.8)
     drb (2.2.1)
     ed25519 (1.3.0)
+    email_validator (2.2.4)
+      activemodel
     erubi (1.13.1)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -304,6 +306,7 @@ DEPENDENCIES
   brakeman
   debug
   dotenv
+  email_validator
   jbuilder
   jwt
   kamal

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::API
   include Pagy::Backend
 
   before_action :authenticate_user
+  before_action :normalize_pagination_params
   after_action { pagy_headers_merge(@pagy) if @pagy }
 
   def render_error(error, http_status)
@@ -20,6 +21,16 @@ class ApplicationController < ActionController::API
       @current_user = User.find_by(id: decoded[:user_id])
     else
       render_error("Unauthorized", :unauthorized)
+    end
+  end
+
+  def normalize_pagination_params
+    if params[:page].to_i <= 0
+      params[:page] = "1"
+    end
+
+    if params[:limit].to_i <= 0
+      params[:limit] = "#{Pagy::DEFAULT[:limit]}"
     end
   end
 end

--- a/app/models/clock_in.rb
+++ b/app/models/clock_in.rb
@@ -29,7 +29,7 @@ class ClockIn < ApplicationRecord
       clock_in_at: 7.days.ago...
     }
 
-    if options[:exclude_unfinished]
+    if options[:exclude_unfinished] == "true"
       query[:duration] = Range.new(1, nil)
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,4 +9,5 @@ class User < ApplicationRecord
 
   validates :email, presence: true, uniqueness: true
   validates :password_digest, presence: true
+  validates :email, email: true
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -32,6 +32,14 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_response :created
   end
 
+  test "should not create user if email invalid" do
+    assert_difference("User.count", 0) do
+      post users_url, params: { user: { email: "testemail.com", name: @user.name, password: "test", password_confirmation: "test" } }, as: :json
+    end
+
+    assert_response 422
+  end
+
   test "should not create user if required params are missing" do
     assert_difference("User.count", 0) do
       post users_url, params: { user: { name: @user.name, password: "test", password_confirmation: "test" } }, as: :json


### PR DESCRIPTION
- Fix the `exclude_unfinished` condition on API `GET /users/:user_id/clock-ins/followings`. Previously, any given values in `exclude_unfinished` will be regarded as `true`. Now we only consider `exclude_unfinished=true` as `true`
- Fix edge case when either `page` or `limit` params is <= 0. Now it will fallback to default `page` / `limit` values
- Add simple email validation to handle invalid `email` address from user on register API `POST /users`